### PR TITLE
Fixed uninitialized pointer to struct (caused GCC to throws an error …

### DIFF
--- a/src/clus.c
+++ b/src/clus.c
@@ -28,7 +28,7 @@ static void domains_get_cb(EV_P_ struct botz_entry *e,
   struct hlist_node *n = NULL;
   size_t i = 0;
   char *d = NULL;
-  struct clus_node *c;
+  struct clus_node *c = NULL;
 
   while (str_table_for_each(&domain_clus_table, &i, &n, &d, (void **) &c))
     n_buf_printf(nb, "%s %s\n", d, c->c_x.x_name);


### PR DESCRIPTION
Forcing a pointer to a 'clus_node' struct to NULL (avoid GCC to throws an error while
compiling xltop.

(Refers to https://github.com/jhammond/xltop/issues/2)