### PR TITLE
Fixed memset call using explicitely a dereferenced pointer

### DIFF
--- a/src/curl_x.c
+++ b/src/curl_x.c
@@ -10,7 +10,7 @@ void curl_x_destroy(struct curl_x *cx)
   if (cx->cx_curl != NULL)
     curl_easy_cleanup(cx->cx_curl);
   free(cx->cx_host);
-  memset(cx, 0, sizeof(cx));
+  memset(cx, 0, sizeof(*cx));
 }
 
 int curl_x_init(struct curl_x *cx, const char *host, const char *port)


### PR DESCRIPTION
Fixed a compilation issues with GCC 4.8/4.9 (stricter guidelines).