### PR TITLE
Added -lm switch (avoid linking errors with GNU ld recent versions)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,11 +14,11 @@ bin_PROGRAMS = xltop xltop-clusd xltop-master xltop-servd
 
 xltop_SOURCES = xltop.c hash.c n_buf.c screen.c curl_x.c
 
-xltop_LDADD = -lcurl -lev -lncurses
+xltop_LDADD = -lcurl -lev -lncurses -lm
 
 xltop_clusd_SOURCES = clusd.c curl_x.c n_buf.c
 
-xltop_clusd_LDADD = -lcurl -lev
+xltop_clusd_LDADD = -lcurl -lev -lm
 
 xltop_master_SOURCES = \
 	master.c ap_parse.c hash.c x_node.c sub.c \
@@ -27,8 +27,8 @@ xltop_master_SOURCES = \
 	n_buf.c evx_listen.c x_botz.c botz.c \
 	pidfile.c
 
-xltop_master_LDADD = -lconfuse -lev -lncurses
+xltop_master_LDADD = -lconfuse -lev -lncurses -lm
 
 xltop_servd_SOURCES = servd.c curl_x.c hash.c n_buf.c pidfile.c
 
-xltop_servd_LDADD = -lcurl -lev
+xltop_servd_LDADD = -lcurl -lev -lm


### PR DESCRIPTION
Explicit link the libm library avoid errors with GNU ld recent versions
